### PR TITLE
upgrades

### DIFF
--- a/charts/audiobookshelf/Chart.lock
+++ b/charts/audiobookshelf/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: istio-ingress
   repository: https://mbround18.github.io/helm-charts
-  version: 0.1.4
+  version: 0.1.9
 - name: gitops-tools
   repository: https://mbround18.github.io/helm-charts
   version: 0.1.1
-digest: sha256:a208ab8a08a1fdc8d4930a2565ca5fc9f236ace4d787721bd68bfbecd6aa3f45
-generated: "2026-05-18T20:56:05.237765819Z"
+digest: sha256:9842ef7ab4f7b0b3674445a6123c5bd9e18e7f782fb0e88dbde190cf8fada31d
+generated: "2026-05-29T21:55:23.018791556Z"

--- a/charts/audiobookshelf/Chart.yaml
+++ b/charts/audiobookshelf/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.13
 appVersion: 2.19.0
 dependencies:
 - name: istio-ingress
-  version: 0.1.4
+  version: 0.1.9
   repository: https://mbround18.github.io/helm-charts
   condition: istio-ingress.enabled
 - name: gitops-tools

--- a/charts/foundryvtt/Chart.lock
+++ b/charts/foundryvtt/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: istio-ingress
   repository: https://mbround18.github.io/helm-charts
-  version: 0.1.4
+  version: 0.1.9
 - name: gitops-tools
   repository: https://mbround18.github.io/helm-charts
   version: 0.1.1
-digest: sha256:a208ab8a08a1fdc8d4930a2565ca5fc9f236ace4d787721bd68bfbecd6aa3f45
-generated: "2026-05-18T20:56:39.176190322Z"
+digest: sha256:9842ef7ab4f7b0b3674445a6123c5bd9e18e7f782fb0e88dbde190cf8fada31d
+generated: "2026-05-29T21:55:32.813244011Z"

--- a/charts/foundryvtt/Chart.yaml
+++ b/charts/foundryvtt/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 - name: mbround18
 dependencies:
 - name: istio-ingress
-  version: 0.1.4
+  version: 0.1.9
   repository: https://mbround18.github.io/helm-charts
   condition: istio-ingress.enabled
 - name: gitops-tools

--- a/charts/grafana/Chart.lock
+++ b/charts/grafana/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 7.3.12
+  version: 10.5.15
 - name: istio-ingress
   repository: file://../istio-ingress
   version: 0.1.10
 - name: gitops-tools
   repository: file://../gitops-tools
   version: 0.1.1
-digest: sha256:22b8828a03096c79b9ca2d2b84c7c73dc887e84219dd2b9b5e0b75f8481f488e
-generated: "2026-05-29T21:54:06.259254046Z"
+digest: sha256:0ad7278e234e3a8889484e23c8beb2ae8439bd1217b733434657f904900e1cc8
+generated: "2026-05-29T21:56:15.527678994Z"

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.1
 appVersion: 10.4.1
 dependencies:
 - name: grafana
-  version: 7.3.12
+  version: 10.5.15
   repository: https://grafana.github.io/helm-charts
   alias: upstream-grafana
 - name: istio-ingress

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: ""
 
 image:
   repository: quay.io/keycloak/keycloak
-  tag: "26.4.0"
+  tag: "26.6.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/meilisearch/Chart.lock
+++ b/charts/meilisearch/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: istio-ingress
   repository: https://mbround18.github.io/helm-charts
-  version: 0.1.4
-digest: sha256:451ff1a1fab8f1e4f2b1648a77fbcbc50188b29ad5de661fc098bb511944c091
-generated: "2026-04-29T21:50:11.763473155Z"
+  version: 0.1.9
+digest: sha256:55cab00dd81f8eabcf59b37f44227640016fde7046cf82e8658d9b12774c0693
+generated: "2026-05-29T21:55:41.483410116Z"

--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -6,6 +6,6 @@ version: 0.1.23
 appVersion: v1.30.0
 dependencies:
 - name: istio-ingress
-  version: 0.1.4
+  version: 0.1.9
   repository: https://mbround18.github.io/helm-charts
   condition: istio-ingress.enabled

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -16,7 +16,7 @@ image:
   repository: otel/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
   # Default tag is .Chart.AppVersion
-  tag: "0.152.0-386"
+  tag: "0.153.0-386"
 
 imagePullSecrets: []
 

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -11,7 +11,7 @@ authMethod: scram-sha-256
 
 image:
   repository: postgres
-  tag: "18.3"
+  tag: "18.4"
   pullPolicy: IfNotPresent
 
 ha:

--- a/charts/syncthing/Chart.lock
+++ b/charts/syncthing/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: istio-ingress
   repository: https://mbround18.github.io/helm-charts
-  version: 0.1.4
+  version: 0.1.9
 - name: gitops-tools
   repository: https://mbround18.github.io/helm-charts
   version: 0.1.1
-digest: sha256:a208ab8a08a1fdc8d4930a2565ca5fc9f236ace4d787721bd68bfbecd6aa3f45
-generated: "2026-05-18T20:57:29.111030366Z"
+digest: sha256:9842ef7ab4f7b0b3674445a6123c5bd9e18e7f782fb0e88dbde190cf8fada31d
+generated: "2026-05-29T21:55:49.368941388Z"

--- a/charts/syncthing/Chart.yaml
+++ b/charts/syncthing/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.12
 appVersion: 2.0.16
 dependencies:
 - name: istio-ingress
-  version: 0.1.4
+  version: 0.1.9
   repository: https://mbround18.github.io/helm-charts
   condition: istio-ingress.enabled
 - name: gitops-tools

--- a/charts/syncthing/values.yaml
+++ b/charts/syncthing/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: syncthing/syncthing
-  tag: 2.0.16
+  tag: 2.1.0
   pullPolicy: IfNotPresent
 
 replicaCount: 1
@@ -70,6 +70,6 @@ securityContext:
 initChown:
   # If enabled, an initContainer will chown the mounted volumes to the rootless UID/GID
   enabled: true
-  image: syncthing/syncthing:2.0.16
+  image: syncthing/syncthing:2.1.0
   # Extra directories the chown init container should ensure (optional)
   extraDirs: []

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: ""
 
 image:
   repository: vaultwarden/server
-  tag: 1.35.7
+  tag: 1.36.0
   pullPolicy: IfNotPresent
 
 revisionHistoryLimit: 10

--- a/charts/wikijs/Chart.lock
+++ b/charts/wikijs/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.1.4
 - name: meilisearch
   repository: https://mbround18.github.io/helm-charts
-  version: 0.1.16
-digest: sha256:bd7d694d5ebb7c265dcb499f8e265d82b7c8318323b4d40e57b03587c99fc685
-generated: "2026-04-29T14:57:40.432257637-07:00"
+  version: 0.1.22
+digest: sha256:6aef83395376998c1cdee1e5ba06f2ed526eed40aa5194c5ac57d3852652e15c
+generated: "2026-05-22T18:53:38.586880556Z"

--- a/charts/wikijs/Chart.lock
+++ b/charts/wikijs/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgres
   repository: https://mbround18.github.io/helm-charts
-  version: 0.1.17
+  version: 0.1.22
 - name: istio-ingress
   repository: https://mbround18.github.io/helm-charts
   version: 0.1.4
 - name: meilisearch
   repository: https://mbround18.github.io/helm-charts
   version: 0.1.16
-digest: sha256:bd7d694d5ebb7c265dcb499f8e265d82b7c8318323b4d40e57b03587c99fc685
-generated: "2026-04-29T14:57:40.432257637-07:00"
+digest: sha256:4d158ebdfdf21440eb6bf6a14b7a0c6fc310436da55173ae59d03da97cc2ad55
+generated: "2026-05-22T18:53:59.451066135Z"

--- a/charts/wikijs/Chart.lock
+++ b/charts/wikijs/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.17
 - name: istio-ingress
   repository: https://mbround18.github.io/helm-charts
-  version: 0.1.4
+  version: 0.1.9
 - name: meilisearch
   repository: https://mbround18.github.io/helm-charts
   version: 0.1.16
-digest: sha256:bd7d694d5ebb7c265dcb499f8e265d82b7c8318323b4d40e57b03587c99fc685
-generated: "2026-04-29T14:57:40.432257637-07:00"
+digest: sha256:49a9d2317e31189a207b1f46fd701f509f16eaf043881526a4ead992e1eaad87
+generated: "2026-05-29T21:55:58.533570455Z"

--- a/charts/wikijs/Chart.yaml
+++ b/charts/wikijs/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   version: 0.1.17
   repository: https://mbround18.github.io/helm-charts
 - name: istio-ingress
-  version: 0.1.4
+  version: 0.1.9
   repository: https://mbround18.github.io/helm-charts
   condition: istio-ingress.enabled
 - name: meilisearch

--- a/charts/wikijs/Chart.yaml
+++ b/charts/wikijs/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.2.37
 appVersion: '2.5'
 dependencies:
 - name: postgres
-  version: 0.1.17
+  version: 0.1.22
   repository: https://mbround18.github.io/helm-charts
 - name: istio-ingress
   version: 0.1.4

--- a/charts/wikijs/Chart.yaml
+++ b/charts/wikijs/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
   repository: https://mbround18.github.io/helm-charts
   condition: istio-ingress.enabled
 - name: meilisearch
-  version: 0.1.16
+  version: 0.1.22
   repository: https://mbround18.github.io/helm-charts
   condition: meilisearch.enabled

--- a/charts/wikijs/values.yaml
+++ b/charts/wikijs/values.yaml
@@ -95,7 +95,7 @@ postgres:
     enabled: false
   image:
     repository: postgres
-    tag: "18.3"
+    tag: "18.4"
     pullPolicy: IfNotPresent
   persistence:
     enabled: true

--- a/charts/wikijs/values.yaml
+++ b/charts/wikijs/values.yaml
@@ -5,7 +5,7 @@ global:
 replicaCount: 1
 image:
   repository: ghcr.io/requarks/wiki
-  tag: 2.5.277
+  tag: 2.5.314
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
- **Update ghcr.io/requarks/wiki Docker tag to v2.5.314**
- **Update vaultwarden/server Docker tag to v1.36.0**
- **Update postgres Docker tag to v18.4**
- **Update syncthing/syncthing Docker tag to v2.1.0**
- **Update quay.io/keycloak/keycloak Docker tag to v26.6.2**
- **Update Helm release meilisearch to v0.1.22**
- **Update Helm release postgres to v0.1.22**
- **Update otel/opentelemetry-collector-contrib Docker tag to v0.153.0**
- **Update Helm release istio-ingress to v0.1.9**
- **Update Helm release grafana to v10**
