### PR TITLE
Add keygen and redis charts

### DIFF
--- a/charts/keygen/.helmignore
+++ b/charts/keygen/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/keygen/Chart.lock
+++ b/charts/keygen/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: postgres
+  repository: file://../postgres
+  version: 0.1.27
+- name: redis
+  repository: file://../redis
+  version: 0.1.0
+- name: gitops-tools
+  repository: file://../gitops-tools
+  version: 0.1.1
+digest: sha256:b256c6bb1cef6fd1e3e00320f21fc4b2bcbb504784375ae0a619761c86f22252
+generated: "2026-08-06T10:20:15.752213227-07:00"

--- a/charts/keygen/Chart.yaml
+++ b/charts/keygen/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: keygen
+description: A Helm chart for Keygen, a self-hosted software licensing and distribution API.
+type: application
+version: 0.1.0
+appVersion: latest
+icon: https://keygen.sh/favicon.ico
+keywords:
+  - keygen
+  - licensing
+  - software-licensing
+home: https://keygen.sh/
+sources:
+  - https://github.com/keygen-sh/keygen-api
+dependencies:
+  - name: postgres
+    version: 0.1.27
+    repository: file://../postgres
+    condition: postgres.enabled
+  - name: redis
+    version: 0.1.0
+    repository: file://../redis
+    condition: redis.enabled
+  - name: gitops-tools
+    version: 0.1.1
+    repository: file://../gitops-tools
+maintainers:
+  - name: mbround18

--- a/charts/keygen/README.md
+++ b/charts/keygen/README.md
@@ -1,0 +1,82 @@
+# Keygen
+
+## Description
+
+A Helm chart for deploying [Keygen](https://keygen.sh/docs/self-hosting/) -- a self-hosted
+software licensing and distribution API -- along with its two required backing services,
+PostgreSQL and Redis (bundled as the local `postgres` and `redis` charts in this repository).
+
+The chart deploys:
+
+- A **web** Deployment running `keygen/api web` (Puma), exposed via a Service (and optionally
+  an Ingress).
+- A **worker** Deployment running `keygen/api worker` (Sidekiq), enabled by default
+  (`worker.enabled`).
+- A pre-install/pre-upgrade **migration Job** running `keygen/api release` to apply database
+  migrations before the web/worker Deployments roll out.
+
+Keygen only reads its database and cache configuration from `DATABASE_URL`/`REDIS_URL`
+connection strings, not discrete host/port/user/password env vars. Since the Postgres password
+lives in a separately-managed Secret (created by the `postgres` subchart), the container command
+assembles both URLs from discrete `DB_*`/`REDIS_*` env vars at startup before handing off to the
+image's entrypoint (`/app/scripts/entrypoint.sh`) -- see `templates/_env.tpl`.
+
+## Secrets
+
+On first install this chart generates and stores Keygen's required application secrets
+(`SECRET_KEY_BASE`, `ENCRYPTION_DETERMINISTIC_KEY`, `ENCRYPTION_PRIMARY_KEY`,
+`ENCRYPTION_KEY_DERIVATION_SALT`) and a `KEYGEN_ACCOUNT_ID` UUID in a Secret named
+`{fullname}-secrets` (override via `secrets.name`). Re-running `helm upgrade` reuses the existing
+Secret instead of rotating it, so account data stays decryptable across upgrades. Set
+`secrets.create=false` to bring your own pre-existing Secret with the same keys instead.
+
+The Postgres and Redis passwords are managed by their respective subcharts; see
+[postgres](../postgres/README.md) and [redis](../redis/README.md).
+
+## Quick Start
+
+```bash
+helm repo add mbround18 https://mbround18.github.io/helm-charts/
+helm repo update
+helm install keygen mbround18/keygen \
+  --namespace keygen --create-namespace \
+  --set keygen.host=licensing.example.com \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=licensing.example.com
+```
+
+`keygen.host` must be a real, resolvable domain name -- Keygen refuses to boot with an IP
+address here. Whatever reverse proxy/ingress controller terminates TLS in front of this Service
+must forward `X-Forwarded-Proto`, `X-Forwarded-For`, and `X-Forwarded-Host`.
+
+## Enterprise Edition
+
+Set `keygen.edition=EE` and `license.enabled=true` with `license.secretName` pointing at a Secret
+containing your license file (key `license.secretKey`, default `ee.lic`) to mount it at
+`/etc/keygen/ee.lic`.
+
+## Configuration
+
+| Parameter                 | Description                                                  | Default           |
+| ------------------------- | ------------------------------------------------------------ | ----------------- |
+| image.repository          | Container image repository                                   | `"keygen/api"`    |
+| image.tag                 | Image tag/version                                            | `"latest"`        |
+| keygen.host               | Public domain name (required, never an IP)                   | `"keygen.local"`  |
+| keygen.edition            | `CE` or `EE`                                                 | `"CE"`            |
+| keygen.mode               | `singleplayer` or `multiplayer`                              | `"singleplayer"`  |
+| keygen.accountId          | UUID used in singleplayer mode; auto-generated if empty      | `""`              |
+| secrets.create            | Auto-generate SECRET_KEY_BASE/ENCRYPTION_*/KEYGEN_ACCOUNT_ID | `true`            |
+| worker.enabled            | Deploy the Sidekiq worker Deployment                         | `true`            |
+| worker.sidekiqConcurrency | Sidekiq thread concurrency                                   | `10`              |
+| migrations.enabled        | Run `keygen/api release` as a pre-install/upgrade hook Job   | `true`            |
+| license.enabled           | Mount an EE license file at `/etc/keygen`                    | `false`           |
+| postgres.enabled          | Deploy the bundled `postgres` subchart                       | `true`            |
+| redis.enabled             | Deploy the bundled `redis` subchart                          | `true`            |
+| ingress.enabled           | Create a Kubernetes Ingress                                  | `false`           |
+| service.port              | Service/container port                                       | `3000`            |
+| resources                 | Web/migration CPU/memory requests/limits                     | see `values.yaml` |
+| worker.resources          | Worker CPU/memory requests/limits                            | see `values.yaml` |
+
+For full configuration options, see [values.yaml](values.yaml). For the full list of environment
+variables Keygen supports (object storage, email, SSO, rate limiting, etc.), see the
+[self-hosting docs](https://keygen.sh/docs/self-hosting/).

--- a/charts/keygen/templates/NOTES.txt
+++ b/charts/keygen/templates/NOTES.txt
@@ -1,0 +1,31 @@
+Keygen is deploying. Once the migration Job has completed and the web
+Deployment is ready, the API will be reachable inside the cluster at:
+
+  http://{{ include "keygen.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+{{- if .Values.ingress.enabled }}
+
+and externally at:
+{{- range .Values.ingress.hosts }}
+  http://{{ .host }}
+{{- end }}
+{{- else }}
+
+Ingress is disabled. Set ingress.enabled=true (or front the Service with your
+own reverse proxy / load balancer) to expose it -- Keygen requires TLS
+termination and X-Forwarded-* headers from whatever sits in front of it.
+{{- end }}
+
+KEYGEN_HOST is set to "{{ .Values.keygen.host }}" -- this must be a real,
+resolvable domain name pointed at your ingress; Keygen refuses to boot with
+an IP address here.
+
+Check the API is healthy:
+
+  kubectl -n {{ .Release.Namespace }} exec deploy/{{ include "keygen.fullname" . }} -- wget -qO- http://localhost:{{ .Values.keygen.port }}/v1/health
+
+{{- if not .Values.worker.enabled }}
+
+worker.enabled is false: background jobs (webhooks, emails, license
+validation callbacks) will not run.
+{{- end }}

--- a/charts/keygen/templates/_env.tpl
+++ b/charts/keygen/templates/_env.tpl
@@ -1,0 +1,93 @@
+{{/*
+Shared container env for the web Deployment, worker Deployment, and
+migration Job. DATABASE_URL/REDIS_URL are single connection-string env vars
+(Keygen's Rails config only reads the URL form, not discrete host/port/user
+vars), so the password pieces are passed in separately and assembled by
+"keygen.entrypointCommand" at container startup.
+*/}}
+{{- define "keygen.env" -}}
+- name: RAILS_ENV
+  value: {{ .Values.keygen.railsEnv | quote }}
+- name: RAILS_LOG_LEVEL
+  value: {{ .Values.keygen.railsLogLevel | quote }}
+- name: PORT
+  value: {{ .Values.keygen.port | quote }}
+- name: BIND
+  value: "0.0.0.0"
+- name: KEYGEN_HOST
+  value: {{ .Values.keygen.host | quote }}
+{{- with .Values.keygen.hosts }}
+- name: KEYGEN_HOSTS
+  value: {{ . | quote }}
+{{- end }}
+- name: KEYGEN_EDITION
+  value: {{ .Values.keygen.edition | quote }}
+- name: KEYGEN_MODE
+  value: {{ .Values.keygen.mode | quote }}
+- name: SECRET_KEY_BASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "keygen.secretsName" . }}
+      key: SECRET_KEY_BASE
+- name: ENCRYPTION_DETERMINISTIC_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "keygen.secretsName" . }}
+      key: ENCRYPTION_DETERMINISTIC_KEY
+- name: ENCRYPTION_PRIMARY_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "keygen.secretsName" . }}
+      key: ENCRYPTION_PRIMARY_KEY
+- name: ENCRYPTION_KEY_DERIVATION_SALT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "keygen.secretsName" . }}
+      key: ENCRYPTION_KEY_DERIVATION_SALT
+- name: KEYGEN_ACCOUNT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "keygen.secretsName" . }}
+      key: KEYGEN_ACCOUNT_ID
+- name: DB_HOST
+  value: {{ include "keygen.postgresHost" . }}
+- name: DB_PORT
+  value: "5432"
+- name: DB_NAME
+  value: {{ .Values.postgres.postgresql.db | quote }}
+- name: DB_USER
+  value: {{ .Values.postgres.postgresql.user | quote }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.postgres.secrets.password.name }}
+      key: {{ .Values.postgres.secrets.password.key }}
+- name: REDIS_HOST
+  value: {{ include "keygen.redisHost" . }}
+- name: REDIS_PORT
+  value: "6379"
+{{- if .Values.redis.auth.enabled }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.redis.auth.existingSecret }}
+      key: {{ .Values.redis.auth.existingSecretKey }}
+{{- end }}
+{{- end }}
+
+{{/*
+Wraps the image's fixed entrypoint (/app/scripts/entrypoint.sh) so that
+DATABASE_URL and REDIS_URL -- the only connection forms Keygen reads -- get
+assembled from the discrete DB_ and REDIS_ env vars above before handing off
+to the given process type ("web", "worker", or "release").
+*/}}
+{{- define "keygen.entrypointCommand" -}}
+command:
+  - sh
+  - -c
+  - |
+    set -e
+    export DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+    export REDIS_URL="redis://{{ if .root.Values.redis.auth.enabled }}:${REDIS_PASSWORD}@{{ end }}${REDIS_HOST}:${REDIS_PORT}"
+    exec /app/scripts/entrypoint.sh {{ .process }}
+{{- end }}

--- a/charts/keygen/templates/_helpers.tpl
+++ b/charts/keygen/templates/_helpers.tpl
@@ -1,0 +1,103 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keygen.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keygen.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keygen.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keygen.labels" -}}
+helm.sh/chart: {{ include "keygen.chart" . }}
+{{ include "keygen.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- include "gitops-tools.argocd.labels" (dict "context" .) }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keygen.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keygen.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Worker selector labels (distinct component so the web/worker Deployments
+never overlap in Service selection).
+*/}}
+{{- define "keygen.workerSelectorLabels" -}}
+{{ include "keygen.selectorLabels" . }}
+app.kubernetes.io/component: worker
+{{- end }}
+
+{{- define "keygen.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keygen.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the app's own generated secrets
+(SECRET_KEY_BASE, ENCRYPTION_*, KEYGEN_ACCOUNT_ID).
+*/}}
+{{- define "keygen.secretsName" -}}
+{{- default (printf "%s-secrets" (include "keygen.fullname" .)) .Values.secrets.name }}
+{{- end }}
+
+{{/*
+Postgres host as reached inside the cluster. Assumes the bundled postgres
+subchart named "postgres" -- override via .Values.postgres.host if pointing
+at an external database.
+*/}}
+{{- define "keygen.postgresHost" -}}
+{{- if .Values.postgres.host }}
+{{- .Values.postgres.host }}
+{{- else }}
+{{- printf "%s-postgres" .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Redis host as reached inside the cluster. Assumes the bundled redis
+subchart named "redis" -- override via .Values.redis.host if pointing at an
+external Redis.
+*/}}
+{{- define "keygen.redisHost" -}}
+{{- if .Values.redis.host }}
+{{- .Values.redis.host }}
+{{- else }}
+{{- printf "%s-redis" .Release.Name }}
+{{- end }}
+{{- end }}

--- a/charts/keygen/templates/deployment.yaml
+++ b/charts/keygen/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keygen.fullname" . }}
+  labels:
+    {{- include "keygen.labels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "release") }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "keygen.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "keygen.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "keygen.serviceAccountName" . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-postgres
+          image: alpine:3.22
+          command:
+            - sh
+            - -c
+            - |
+              apk add --no-cache postgresql-client
+              until pg_isready -h {{ include "keygen.postgresHost" . }} -p 5432 -U {{ .Values.postgres.postgresql.user | quote }}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 5
+              done
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        - name: wait-for-redis
+          image: alpine:3.22
+          command:
+            - sh
+            - -c
+            - |
+              apk add --no-cache redis
+              until redis-cli -h {{ include "keygen.redisHost" . }} -p 6379 ping; do
+                echo "Waiting for Redis to be ready..."
+                sleep 5
+              done
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: keygen
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- include "keygen.entrypointCommand" (dict "root" . "process" "web") | nindent 10 }}
+          env:
+            {{- include "keygen.env" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.keygen.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.license.enabled }}
+          volumeMounts:
+            - name: license
+              mountPath: /etc/keygen
+              readOnly: true
+          {{- end }}
+      {{- if .Values.license.enabled }}
+      volumes:
+        - name: license
+          secret:
+            secretName: {{ .Values.license.secretName }}
+            items:
+              - key: {{ .Values.license.secretKey }}
+                path: ee.lic
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/keygen/templates/ingress.yaml
+++ b/charts/keygen/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "keygen.fullname" . }}
+  labels:
+    {{- include "keygen.labels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "ingress" "annotations" .Values.ingress.annotations) }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "keygen.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/keygen/templates/migration-job.yaml
+++ b/charts/keygen/templates/migration-job.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "keygen.fullname" . }}-migrate-{{ .Release.Revision }}
+  labels:
+    {{- include "keygen.labels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "supporting" "annotations" (dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "0" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "keygen.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "keygen.serviceAccountName" . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-postgres
+          image: alpine:3.22
+          command:
+            - sh
+            - -c
+            - |
+              apk add --no-cache postgresql-client
+              until pg_isready -h {{ include "keygen.postgresHost" . }} -p 5432 -U {{ .Values.postgres.postgresql.user | quote }}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 5
+              done
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: keygen-migrate
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- include "keygen.entrypointCommand" (dict "root" . "process" "release") | nindent 10 }}
+          env:
+            {{- include "keygen.env" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/charts/keygen/templates/secrets.yaml
+++ b/charts/keygen/templates/secrets.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.secrets.create }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (include "keygen.secretsName" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "keygen.secretsName" . }}
+  labels:
+    {{- include "keygen.labels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "foundation") }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+stringData:
+  {{- if $secret }}
+  SECRET_KEY_BASE: {{ index $secret.data "SECRET_KEY_BASE" | b64dec }}
+  ENCRYPTION_DETERMINISTIC_KEY: {{ index $secret.data "ENCRYPTION_DETERMINISTIC_KEY" | b64dec }}
+  ENCRYPTION_PRIMARY_KEY: {{ index $secret.data "ENCRYPTION_PRIMARY_KEY" | b64dec }}
+  ENCRYPTION_KEY_DERIVATION_SALT: {{ index $secret.data "ENCRYPTION_KEY_DERIVATION_SALT" | b64dec }}
+  KEYGEN_ACCOUNT_ID: {{ index $secret.data "KEYGEN_ACCOUNT_ID" | b64dec }}
+  {{- else }}
+  SECRET_KEY_BASE: {{ randAlphaNum 128 | quote }}
+  ENCRYPTION_DETERMINISTIC_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  ENCRYPTION_PRIMARY_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  ENCRYPTION_KEY_DERIVATION_SALT: {{ randAlphaNum 32 | b64enc | quote }}
+  KEYGEN_ACCOUNT_ID: {{ .Values.keygen.accountId | default uuidv4 | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/keygen/templates/service.yaml
+++ b/charts/keygen/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keygen.fullname" . }}
+  labels:
+    {{- include "keygen.labels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "ingress") }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "keygen.selectorLabels" . | nindent 4 }}

--- a/charts/keygen/templates/serviceaccount.yaml
+++ b/charts/keygen/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "keygen.serviceAccountName" . }}
+  labels:
+    {{- include "keygen.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/keygen/templates/worker-deployment.yaml
+++ b/charts/keygen/templates/worker-deployment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keygen.fullname" . }}-worker
+  labels:
+    {{- include "keygen.workerSelectorLabels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "release") }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "keygen.workerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "keygen.workerSelectorLabels" . | nindent 8 }}
+    spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "keygen.serviceAccountName" . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-postgres
+          image: alpine:3.22
+          command:
+            - sh
+            - -c
+            - |
+              apk add --no-cache postgresql-client
+              until pg_isready -h {{ include "keygen.postgresHost" . }} -p 5432 -U {{ .Values.postgres.postgresql.user | quote }}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 5
+              done
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        - name: wait-for-redis
+          image: alpine:3.22
+          command:
+            - sh
+            - -c
+            - |
+              apk add --no-cache redis
+              until redis-cli -h {{ include "keygen.redisHost" . }} -p 6379 ping; do
+                echo "Waiting for Redis to be ready..."
+                sleep 5
+              done
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: keygen-worker
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- include "keygen.entrypointCommand" (dict "root" . "process" "worker") | nindent 10 }}
+          env:
+            {{- include "keygen.env" . | nindent 12 }}
+            - name: SIDEKIQ_CONCURRENCY
+              value: {{ .Values.worker.sidekiqConcurrency | quote }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/keygen/tests/test_keygen.py
+++ b/charts/keygen/tests/test_keygen.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+
+from charts.test_helpers import DEFAULT_NAMESPACE, render_chart_documents
+
+
+def _render(values=None, api_versions=None):
+    chart_path = Path(__file__).parent.parent
+    return render_chart_documents(
+        chart_path,
+        namespace=DEFAULT_NAMESPACE,
+        values=values,
+        api_versions=api_versions,
+    )
+
+
+def _is_keygen_owned(document):
+    labels = (document.get("metadata") or {}).get("labels") or {}
+    return labels.get("app.kubernetes.io/name") == "keygen"
+
+
+def _document_by_kind(documents, kind):
+    return next(
+        doc
+        for doc in documents
+        if doc.get("kind") == kind and _is_keygen_owned(doc)
+    )
+
+
+def _documents_by_kind(documents, kind):
+    return [
+        doc for doc in documents if doc.get("kind") == kind and _is_keygen_owned(doc)
+    ]
+
+
+def _container(pod_spec, name):
+    return next(c for c in pod_spec["containers"] if c["name"] == name)
+
+
+def test_web_deployment_assembles_database_and_redis_url_at_startup():
+    documents = _render()
+
+    deployment = _document_by_kind(documents, "Deployment")
+    container = _container(deployment["spec"]["template"]["spec"], "keygen")
+
+    assert container["command"][0:2] == ["sh", "-c"]
+    script = container["command"][2]
+    assert "DATABASE_URL=" in script
+    assert "REDIS_URL=" in script
+    assert "exec /app/scripts/entrypoint.sh web" in script
+
+    env_names = {env["name"] for env in container["env"]}
+    assert {
+        "SECRET_KEY_BASE",
+        "ENCRYPTION_DETERMINISTIC_KEY",
+        "ENCRYPTION_PRIMARY_KEY",
+        "ENCRYPTION_KEY_DERIVATION_SALT",
+        "KEYGEN_ACCOUNT_ID",
+        "DB_HOST",
+        "DB_PASSWORD",
+        "REDIS_HOST",
+    } <= env_names
+    # Redis auth is disabled by default -- no REDIS_PASSWORD env should be wired.
+    assert "REDIS_PASSWORD" not in env_names
+
+
+def test_worker_deployment_enabled_by_default_runs_worker_process():
+    documents = _render()
+
+    worker = next(
+        doc
+        for doc in _documents_by_kind(documents, "Deployment")
+        if doc["metadata"]["name"].endswith("-worker")
+    )
+    container = _container(
+        worker["spec"]["template"]["spec"], "keygen-worker"
+    )
+
+    assert "exec /app/scripts/entrypoint.sh worker" in container["command"][2]
+
+
+def test_worker_deployment_omitted_when_disabled():
+    documents = _render(values={"worker": {"enabled": False}})
+
+    deployments = _documents_by_kind(documents, "Deployment")
+    assert len(deployments) == 1
+    assert not deployments[0]["metadata"]["name"].endswith("-worker")
+
+
+def test_migration_job_runs_as_pre_install_pre_upgrade_hook():
+    documents = _render()
+
+    job = _document_by_kind(documents, "Job")
+    annotations = job["metadata"]["annotations"]
+
+    assert annotations["helm.sh/hook"] == "pre-install,pre-upgrade"
+    container = _container(job["spec"]["template"]["spec"], "keygen-migrate")
+    assert "exec /app/scripts/entrypoint.sh release" in container["command"][2]
+
+
+def test_migration_job_omitted_when_disabled():
+    documents = _render(values={"migrations": {"enabled": False}})
+
+    assert not _documents_by_kind(documents, "Job")
+
+
+def test_secrets_generated_by_default():
+    documents = _render()
+
+    secret = _document_by_kind(documents, "Secret")
+    assert secret["metadata"]["name"].endswith("-secrets")
+    for key in (
+        "SECRET_KEY_BASE",
+        "ENCRYPTION_DETERMINISTIC_KEY",
+        "ENCRYPTION_PRIMARY_KEY",
+        "ENCRYPTION_KEY_DERIVATION_SALT",
+        "KEYGEN_ACCOUNT_ID",
+    ):
+        assert key in secret["stringData"]
+
+
+def test_secrets_omitted_when_create_disabled():
+    documents = _render(values={"secrets": {"create": False}})
+
+    assert not _documents_by_kind(documents, "Secret")
+
+
+def test_argocd_sync_waves_render_when_application_api_is_available():
+    documents = _render(api_versions=["argoproj.io/v1alpha1/Application"])
+
+    secret = _document_by_kind(documents, "Secret")
+    deployment = _document_by_kind(documents, "Deployment")
+    service = _document_by_kind(documents, "Service")
+    job = _document_by_kind(documents, "Job")
+
+    assert secret["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "0"
+    assert (
+        deployment["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "30"
+    )
+    assert service["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "40"
+    assert job["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "20"

--- a/charts/keygen/values.yaml
+++ b/charts/keygen/values.yaml
@@ -1,0 +1,143 @@
+global:
+  secret:
+    annotations: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+argoCd:
+  mode: auto
+  instanceLabel: ""
+  commonAnnotations: {}
+  commonLabels: {}
+
+image:
+  repository: keygen/api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# https://keygen.sh/docs/self-hosting/
+keygen:
+  # Must be a domain name (never an IP) -- keygen enforces this and refuses
+  # to boot otherwise.
+  host: keygen.local
+  # Additional accessible domains, comma-separated.
+  hosts: ""
+  # CE (Community Edition, default) or EE (Enterprise Edition, requires a license).
+  edition: CE
+  # singleplayer (default, single-tenant) or multiplayer (multi-tenant).
+  mode: singleplayer
+  # Left empty, a UUID is generated once and stored in the app Secret.
+  accountId: ""
+  railsEnv: production
+  railsLogLevel: info
+  port: 3000
+
+# Required application secrets (SECRET_KEY_BASE, ENCRYPTION_*). Generated
+# once and persisted in this Secret; never accepted as plaintext Helm
+# values. Re-running helm upgrade reuses the existing Secret instead of
+# rotating it.
+secrets:
+  name: ""
+  create: true
+
+worker:
+  enabled: true
+  replicaCount: 1
+  sidekiqConcurrency: 10
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+migrations:
+  enabled: true
+
+# EE-only: mount a license file at /etc/keygen. Ignored for CE.
+license:
+  enabled: false
+  secretName: ""
+  secretKey: ee.lic
+
+postgres:
+  enabled: true
+  secrets:
+    password:
+      name: keygen-postgres-password
+      key: POSTGRES_PASSWORD
+      create: true
+    superuserPassword:
+      name: keygen-postgres-superuser-password
+      key: POSTGRES_PASSWORD
+      create: true
+  ha:
+    enabled: false
+  image:
+    repository: postgres
+    tag: "18.4"
+    pullPolicy: IfNotPresent
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 10Gi
+  postgresql:
+    db: keygen
+    user: keygen
+
+redis:
+  enabled: true
+  auth:
+    enabled: false
+  persistence:
+    enabled: true
+    size: 2Gi
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+podSecurityContext:
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: keygen.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi
+
+nodeSelector: {}
+affinity: {}
+tolerations: []

--- a/charts/redis/.helmignore
+++ b/charts/redis/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/redis/Chart.lock
+++ b/charts/redis/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gitops-tools
+  repository: file://../gitops-tools
+  version: 0.1.1
+digest: sha256:bf7b1fd13eb1c87a6f5023a44b88957413fe4aee0989881b53165b7f9a64b389
+generated: "2026-08-06T10:15:32.708132634-07:00"

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: redis
+description: Redis Helm chart with persistent storage and optional password-secret management
+type: application
+version: 0.1.0
+appVersion: "7"
+dependencies:
+  - name: gitops-tools
+    version: 0.1.1
+    repository: file://../gitops-tools

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -1,0 +1,47 @@
+# Redis
+
+## Description
+
+A Helm chart for deploying Redis on Kubernetes: persistent storage via a StatefulSet
+volumeClaimTemplate (append-only file enabled), and secure defaults (non-root, no privilege
+escalation, all capabilities dropped).
+
+Authentication is disabled by default to mirror a simple single-tenant/local cache-and-queue
+setup. This chart never accepts secret values through Helm values -- enabling `auth.enabled`
+requires pointing `auth.existingSecret` at a Secret you create out-of-band:
+
+```shell
+kubectl -n ${NAMESPACE} create secret generic redis-password \
+  --from-literal=REDIS_PASSWORD=<value>
+```
+
+```yaml
+auth:
+  enabled: true
+  existingSecret: redis-password
+```
+
+## Quick Start
+
+```bash
+helm repo add mbround18 https://mbround18.github.io/helm-charts/
+helm repo update
+helm install redis mbround18/redis --namespace redis --create-namespace
+```
+
+## Configuration
+
+| Parameter              | Description                                                                     | Default            |
+| ---------------------- | ------------------------------------------------------------------------------- | ------------------ |
+| image.repository       | Container image repository                                                      | `"redis"`          |
+| image.tag              | Image tag/version                                                               | `"7-alpine"`       |
+| auth.enabled           | Require a password (`--requirepass`)                                            | `false`            |
+| auth.existingSecret    | Name of a pre-existing Secret holding the password (required when auth.enabled) | `""`               |
+| auth.existingSecretKey | Key within that Secret                                                          | `"REDIS_PASSWORD"` |
+| persistence.enabled    | Use a StatefulSet volumeClaimTemplate                                           | `true`             |
+| persistence.size       | PVC size for append-only data                                                   | `"2Gi"`            |
+| resources              | CPU/memory requests/limits                                                      | see `values.yaml`  |
+| service.type           | Service type (ClusterIP/NodePort/LoadBalancer)                                  | `"ClusterIP"`      |
+| service.port           | Service/container port                                                          | `6379`             |
+
+For full configuration options, see [values.yaml](values.yaml).

--- a/charts/redis/templates/NOTES.txt
+++ b/charts/redis/templates/NOTES.txt
@@ -1,0 +1,16 @@
+Redis is available inside the cluster at:
+
+  {{ include "redis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+{{- if .Values.auth.enabled }}
+
+Authentication is enabled. The password is read from the "{{ .Values.auth.existingSecret }}" Secret
+(key: {{ .Values.auth.existingSecretKey }}). Build a connection URI with that password, e.g.:
+
+  redis://:<password>@{{ include "redis.fullname" . }}:{{ .Values.service.port }}
+{{- else }}
+
+Authentication is disabled (default). Connect with:
+
+  redis://{{ include "redis.fullname" . }}:{{ .Values.service.port }}
+{{- end }}

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redis.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redis.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis.labels" -}}
+helm.sh/chart: {{ include "redis.chart" . }}
+{{ include "redis.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- include "gitops-tools.argocd.labels" (dict "context" .) }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redis.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "redis.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redis.fullname" . }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "database") }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "redis.selectorLabels" . | nindent 4 }}

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "redis.fullname" . }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "database") }}
+  {{- if $annotations }}
+  annotations:
+    {{- $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "redis.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "redis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "redis.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: redis
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.auth.enabled }}
+          {{- if not .Values.auth.existingSecret }}
+          {{- fail "redis: auth.enabled requires auth.existingSecret (a pre-existing Secret name) -- passwords are never accepted via Helm values" }}
+          {{- end }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingSecret }}
+                  key: {{ .Values.auth.existingSecretKey }}
+          command:
+            - sh
+            - -c
+            - exec redis-server --appendonly yes --requirepass "$REDIS_PASSWORD"
+          {{- else }}
+          command:
+            - redis-server
+            - --appendonly
+            - "yes"
+          {{- end }}
+          ports:
+            - containerPort: 6379
+              name: redis
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli {{ if .Values.auth.enabled }}-a "$REDIS_PASSWORD" --no-auth-warning {{ end }}ping
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli {{ if .Values.auth.enabled }}-a "$REDIS_PASSWORD" --no-auth-warning {{ end }}ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- if not .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{- if .Values.persistence.storageClass }}
+        {{- if eq "-" .Values.persistence.storageClass }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        {{- end }}
+  {{- end }}

--- a/charts/redis/tests/test_redis.py
+++ b/charts/redis/tests/test_redis.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+import pytest
+import subprocess
+
+from charts.test_helpers import DEFAULT_NAMESPACE, render_chart_documents
+
+
+def _render(values=None, api_versions=None):
+    chart_path = Path(__file__).parent.parent
+    return render_chart_documents(
+        chart_path,
+        namespace=DEFAULT_NAMESPACE,
+        values=values,
+        api_versions=api_versions,
+    )
+
+
+def _document_by_kind(documents, kind):
+    return next(doc for doc in documents if doc.get("kind") == kind)
+
+
+def _documents_by_kind(documents, kind):
+    return [doc for doc in documents if doc.get("kind") == kind]
+
+
+def test_auth_disabled_by_default_and_no_secret_rendered():
+    documents = _render()
+
+    assert not _documents_by_kind(documents, "Secret")
+
+    statefulset = _document_by_kind(documents, "StatefulSet")
+    container = statefulset["spec"]["template"]["spec"]["containers"][0]
+
+    assert container["command"] == ["redis-server", "--appendonly", "yes"]
+    assert "env" not in container
+
+
+def test_auth_enabled_reads_from_existing_secret_reference():
+    documents = _render(
+        values={"auth": {"enabled": True, "existingSecret": "my-redis-secret"}}
+    )
+
+    assert not _documents_by_kind(documents, "Secret")
+
+    statefulset = _document_by_kind(documents, "StatefulSet")
+    container = statefulset["spec"]["template"]["spec"]["containers"][0]
+    password_env = next(
+        env for env in container["env"] if env["name"] == "REDIS_PASSWORD"
+    )
+
+    assert password_env["valueFrom"]["secretKeyRef"]["name"] == "my-redis-secret"
+    assert password_env["valueFrom"]["secretKeyRef"]["key"] == "REDIS_PASSWORD"
+
+
+def test_auth_enabled_without_existing_secret_fails_to_render():
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        _render(values={"auth": {"enabled": True}})
+
+    assert "auth.existingSecret" in (excinfo.value.stderr or "")
+
+
+def test_no_secret_manifest_is_ever_rendered():
+    # This chart must never accept secret values through Helm values -- only
+    # references (name/key) to a Secret created out-of-band. Assert that
+    # invariant holds across every values combination this chart supports.
+    for values in (
+        None,
+        {"auth": {"enabled": True, "existingSecret": "my-redis-secret"}},
+        {"persistence": {"enabled": False}},
+    ):
+        documents = _render(values=values)
+        assert not _documents_by_kind(documents, "Secret")
+
+
+def test_persistence_uses_volume_claim_template_by_default():
+    documents = _render()
+
+    statefulset = _document_by_kind(documents, "StatefulSet")
+    claim_names = {
+        template["metadata"]["name"]
+        for template in statefulset["spec"]["volumeClaimTemplates"]
+    }
+
+    assert claim_names == {"data"}
+
+
+def test_argocd_sync_waves_render_when_application_api_is_available():
+    documents = _render(api_versions=["argoproj.io/v1alpha1/Application"])
+
+    statefulset = _document_by_kind(documents, "StatefulSet")
+    service = _document_by_kind(documents, "Service")
+
+    assert (
+        statefulset["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "10"
+    )
+    assert service["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "10"

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -1,0 +1,60 @@
+global:
+  secret:
+    annotations: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+argoCd:
+  mode: auto
+  instanceLabel: ""
+  commonAnnotations: {}
+  commonLabels: {}
+
+image:
+  repository: redis
+  tag: "7-alpine"
+  pullPolicy: IfNotPresent
+
+# Disabled by default to mirror a simple single-tenant/local cache-and-queue
+# setup. This chart never accepts the password as a Helm value -- create a
+# Secret out-of-band and point existingSecret at it:
+#   kubectl create secret generic redis-password \
+#     --from-literal=REDIS_PASSWORD=<value>
+# The consuming app's REDIS_URL then needs that same password folded in.
+auth:
+  enabled: false
+  existingSecret: ""
+  existingSecretKey: REDIS_PASSWORD
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 2Gi
+  storageClass: ""
+
+podSecurityContext:
+  fsGroup: 999
+
+securityContext:
+  runAsUser: 999
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+service:
+  type: ClusterIP
+  port: 6379
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary
- Adds a `keygen` chart for self-hosting [Keygen](https://keygen.sh/docs/self-hosting/) (software licensing API): web Deployment (Puma), worker Deployment (Sidekiq, enabled by default), and a pre-install/pre-upgrade migration Job, wired to the existing `postgres` chart and a new `redis` chart.
- Adds a standalone `redis` chart (StatefulSet + Service, non-root, append-only persistence) following the same pattern as the existing `mongo` chart — auth disabled by default, `existingSecret` required to enable it, never accepts a password via Helm values.
- Keygen only reads `DATABASE_URL`/`REDIS_URL` as single connection strings rather than discrete host/port/user/password vars. Since the Postgres password lives in a Secret owned by the `postgres` subchart, the container command wraps the image's fixed entrypoint (`/app/scripts/entrypoint.sh`) in a shell script that assembles both URLs from discrete env vars at startup (`templates/_env.tpl`).
- Keygen's own required app secrets (`SECRET_KEY_BASE`, `ENCRYPTION_*`, `KEYGEN_ACCOUNT_ID`) are auto-generated and persisted idempotently (lookup + `randAlphaNum`), matching the pattern already used by the `postgres` chart's password Secret — `helm upgrade` won't rotate them.

## Test plan
- [x] `helm lint charts/keygen` / `helm lint charts/redis` — clean
- [x] `helm template keygen charts/keygen` renders successfully (ServiceAccount, Secrets, Services, web+worker Deployments, migration Job, bundled postgres/redis)
- [x] `uv run pytest charts/tests/test_manifest_contracts.py` — 174 passed (all charts, including the two new ones)
- [x] `uv run pytest charts` — 295 passed (full suite, including 14 new tests for `keygen`/`redis`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)