### PR TITLE
Bump foundryvtt cleanupImage alpine tag to 20260805

### DIFF
--- a/charts/foundryvtt/Chart.yaml
+++ b/charts/foundryvtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: foundryvtt
 description: A Helm chart for Foundry Virtual Tabletop
 type: application
-version: 0.2.34
+version: 0.2.35
 appVersion: '1.0'
 home: https://foundryvtt.com/
 keywords:

--- a/charts/foundryvtt/values.yaml
+++ b/charts/foundryvtt/values.yaml
@@ -96,7 +96,7 @@ initImage:
   tag: 1.38.0
 cleanupImage:
   repository: alpine
-  tag: "20260127"
+  tag: "20260805"
 
 updateStrategy: {}
 


### PR DESCRIPTION
## Summary
- Bumps `charts/foundryvtt` cleanup init-container image from `alpine:20260127` to `alpine:20260805` (latest dated tag on Docker Hub)
- Bumps chart `version` 0.2.34 → 0.2.35 to reflect the values change

## Test plan
- [ ] CI chart lint/tests pass
- [ ] Confirm `alpine:20260805` pulls successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s39LnvBHfJK7WVGABbkzR