### PR TITLE
Fix keycloak predeploy Job/PVC scheduling deadlock under Flux

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak
 description: A production-ready Keycloak chart with GitOps-aware ordering and secure
   defaults
 type: application
-version: 0.2.16
+version: 0.2.17
 appVersion: 26.4.0
 dependencies:
 - name: istio-ingress

--- a/charts/keycloak/templates/predeploy-jobs.yaml
+++ b/charts/keycloak/templates/predeploy-jobs.yaml
@@ -10,6 +10,17 @@ metadata:
     {{- include "keycloak.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.keycloak.preDeployJobs.waves.seed | quote }}
+    {{- /*
+    Runs as a Helm hook (not a plain Job) so Helm waits for it to
+    complete before the sync-provider/build hooks or the main Deployment
+    are applied. Without this, Flux's helm-controller applies every
+    resource at once and a multi-node cluster can schedule this Job's
+    pod on a different node than the Deployment pod, deadlocking on the
+    shared RWO prebuild volume.
+    */}}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-40"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: {{ .Values.keycloak.preDeployJobs.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.keycloak.preDeployJobs.ttlSecondsAfterFinished }}
@@ -50,6 +61,9 @@ metadata:
     {{- include "keycloak.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.keycloak.preDeployJobs.waves.providers | quote }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-30"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: {{ .Values.keycloak.preDeployJobs.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.keycloak.preDeployJobs.ttlSecondsAfterFinished }}
@@ -101,6 +115,9 @@ metadata:
     {{- include "keycloak.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.keycloak.preDeployJobs.waves.build | quote }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-20"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: {{ .Values.keycloak.preDeployJobs.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.keycloak.preDeployJobs.ttlSecondsAfterFinished }}

--- a/charts/keycloak/templates/predeploy-pvc.yaml
+++ b/charts/keycloak/templates/predeploy-pvc.yaml
@@ -13,6 +13,15 @@ metadata:
     {{- end }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.keycloak.preDeployJobs.waves.storage | quote }}
+    {{- /*
+    Pre-install/pre-upgrade hook: must exist and be Bound before the
+    seed-lib/sync-provider/build predeploy Jobs (also hooks, weight -40
+    through -20) mount it, otherwise the main Deployment pod and a
+    predeploy Job pod can land on different nodes and deadlock on this
+    RWO volume.
+    */}}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-50"
     {{- with .Values.keycloak.preDeployJobs.persistence.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/keycloak/templates/pvc.yaml
+++ b/charts/keycloak/templates/pvc.yaml
@@ -1,3 +1,6 @@
+{{- $enableBuildInit := and .Values.keycloak.production .Values.keycloak.buildInit.enabled }}
+{{- $needsWritableQuarkusLib := or $enableBuildInit (not .Values.keycloak.production) }}
+{{- $usePreDeployJobs := and .Values.keycloak.preDeployJobs.enabled $needsWritableQuarkusLib }}
 {{- if and .Values.persistence.enabled .Values.persistence.create (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -9,6 +12,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- $extraAnnotations := dict }}
+  {{- if $usePreDeployJobs }}
+  {{/*
+  The predeploy build Job mounts this PVC alongside the prebuild PVC.
+  Both must exist and be Bound before any predeploy Job pod is scheduled,
+  otherwise a multi-node cluster can schedule the Deployment pod and a
+  predeploy Job pod on different nodes and deadlock on the RWO volume.
+  Running this as a pre-install/pre-upgrade hook makes Helm create and
+  wait on it before any predeploy Job hook runs.
+  */}}
+  {{- $_ := set $extraAnnotations "helm.sh/hook" "pre-install,pre-upgrade" }}
+  {{- $_ := set $extraAnnotations "helm.sh/hook-weight" "-50" }}
+  {{- end }}
   {{- if .Values.persistence.keep }}
   {{- $_ := set $extraAnnotations "helm.sh/resource-policy" "keep" }}
   {{- end }}


### PR DESCRIPTION
## Summary
- The `keycloak` chart's predeploy PVCs (`prebuild`, `data`) and Jobs (`seed-lib`, `sync-provider`, `build`) were ordered only via `argocd.argoproj.io/sync-wave` annotations, which ArgoCD understands but Flux/plain Helm does not.
- Under Flux's helm-controller, all resources apply in one batch with no ordering or wait-for-completion guarantee. On a multi-node cluster this let the scheduler place a predeploy Job's pod on a different node than the Deployment pod, deadlocking on the shared RWO volume (`Multi-Attach error`) while the Deployment crash-looped on `--optimized` because its build dependency could never run.
- Converts both PVCs and all three Jobs to `pre-install,pre-upgrade` Helm hooks with sequential `helm.sh/hook-weight` (PVCs `-50`, seed-lib `-40`, sync-provider `-30`, build `-20`) and `hook-delete-policy` on the Jobs so they rerun cleanly on every upgrade. Helm now creates the PVCs and waits for each Job to finish, in order, before applying the Deployment — no node-count dependency.
- `argocd.argoproj.io/sync-wave` annotations are untouched, so ArgoCD users are unaffected.
- Bumped chart version 0.2.16 → 0.2.17.

## Test plan
- [x] `helm lint` passes with `preDeployJobs`/`buildInit` enabled
- [x] `helm template` confirms hook annotations/weights render correctly and the stray blank-line artifact from the added template comments is gone
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s39LnvBHfJK7WVGABbkzR