### PR TITLE
Fix keycloak ServiceAccount ordering with predeploy hooks

### DIFF
--- a/charts/keycloak/templates/serviceaccount.yaml
+++ b/charts/keycloak/templates/serviceaccount.yaml
@@ -1,3 +1,6 @@
+{{- $enableBuildInit := and .Values.keycloak.production .Values.keycloak.buildInit.enabled }}
+{{- $needsWritableQuarkusLib := or $enableBuildInit (not .Values.keycloak.production) }}
+{{- $usePreDeployJobs := and .Values.keycloak.preDeployJobs.enabled $needsWritableQuarkusLib }}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -5,7 +8,20 @@ metadata:
   name: {{ include "keycloak.serviceAccountName" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
-  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "foundation" "annotations" .Values.serviceAccount.annotations) }}
+  {{- $extraAnnotations := dict }}
+  {{- if $usePreDeployJobs }}
+  {{- /*
+  The predeploy Jobs (hooks, weight -40 through -20) run as this
+  ServiceAccount, so it must exist before any of them do. Run it as an
+  even earlier hook.
+  */}}
+  {{- $_ := set $extraAnnotations "helm.sh/hook" "pre-install,pre-upgrade" }}
+  {{- $_ := set $extraAnnotations "helm.sh/hook-weight" "-60" }}
+  {{- end }}
+  {{- range $key, $value := .Values.serviceAccount.annotations }}
+  {{- $_ := set $extraAnnotations $key $value }}
+  {{- end }}
+  {{- $annotations := include "gitops-tools.argocd.annotations" (dict "context" . "phase" "foundation" "annotations" $extraAnnotations) }}
   {{- if $annotations }}
   annotations:
     {{- $annotations | nindent 4 }}


### PR DESCRIPTION
## Summary
Follow-up to #178. That PR converted the keycloak predeploy PVCs/Jobs into pre-install hooks (weights -50 through -20) to fix a scheduling deadlock under Flux. It missed that the ServiceAccount those Jobs run as was still a plain (non-hook) resource, applied *after* hooks — so a clean install now fails immediately with `serviceaccount "keycloak" not found`, observed live while rolling out #178's fix.

Gives the ServiceAccount an earlier hook-weight (`-60`) so it's created before anything that depends on it.

## Test plan
- [x] `helm lint` passes with `preDeployJobs`/`buildInit` enabled
- [x] `helm template` confirms the ServiceAccount now renders with the hook annotation
- [ ] CI
- [ ] Live verification against the fluxified cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s39LnvBHfJK7WVGABbkzR